### PR TITLE
feat: add optional support for access token

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  dart_jsonwebtoken:
+    dependency: "direct dev"
+    description:
+      name: dart_jsonwebtoken
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.1"
   dart_style:
     dependency: transitive
     description:
@@ -302,6 +309,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.0"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,12 +5,14 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  http: ^0.13.3
   json_annotation: ^4.0.1
   uuid: ^3.0.4
-  http: ^0.13.3
 
 dev_dependencies:
-  effective_dart: ^1.3.1
-  test: ^1.14.4
   build_runner: ^2.0.3
+  dart_jsonwebtoken: ^2.4.1
+  effective_dart: ^1.3.1
   json_serializable: ^4.1.2
+  test: ^1.14.4
+

--- a/test/src/actuator/health_check_test.dart
+++ b/test/src/actuator/health_check_test.dart
@@ -1,11 +1,13 @@
 import 'package:ksch_dart_client/core.dart';
 import 'package:test/test.dart';
 
+import '../authentication.dart';
+
 void main() {
   late KschApi api;
 
   setUp(() {
-    api = KschApi('http://localhost:8080');
+    api = KschApi('http://localhost:8080', accessToken: mockAccessToken);
   });
 
   test('Should execute health check', () async {

--- a/test/src/authentication.dart
+++ b/test/src/authentication.dart
@@ -1,0 +1,9 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+
+String get mockAccessToken {
+  final jwt = JWT({}, issuer: 'https://noauth-ga2speboxa-ew.a.run.app/');
+  return jwt.sign(
+    SecretKey('\$MOCK_SIGNING_SECRET'),
+    expiresIn: const Duration(seconds: 86400),
+  );
+}

--- a/test/src/patients/patients_resource_test.dart
+++ b/test/src/patients/patients_resource_test.dart
@@ -2,11 +2,13 @@ import 'package:ksch_dart_client/core.dart';
 import 'package:ksch_dart_client/resources.dart';
 import 'package:test/test.dart';
 
+import '../authentication.dart';
+
 void main() {
   late KschApi api;
 
   setUp(() {
-    api = KschApi('http://localhost:8080');
+    api = KschApi('http://localhost:8080', accessToken: mockAccessToken);
   });
 
   test('Should create patient without payload', () async {

--- a/test/src/patients/visits/visits_resource_test.dart
+++ b/test/src/patients/visits/visits_resource_test.dart
@@ -2,11 +2,13 @@ import 'package:ksch_dart_client/core.dart';
 import 'package:ksch_dart_client/src/patients/visits/payload.dart';
 import 'package:test/test.dart';
 
+import '../../authentication.dart';
+
 void main() {
   late KschApi api;
 
   setUp(() {
-    api = KschApi('http://localhost:8080');
+    api = KschApi('http://localhost:8080', accessToken: mockAccessToken);
   });
 
   test('Should start visit', () async {


### PR DESCRIPTION
For making API requests in the integration tests, an access
token needs to be provided.

In the live system, no access token needs to be provided since
the authentication will be done by the BFF via the session cookie.